### PR TITLE
fix newline in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ out/
 # Logs
 logs/
 *.log
+


### PR DESCRIPTION
## Summary
- add a trailing newline to `.gitignore`

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-html')*